### PR TITLE
Force Renovate to use node 14 and npm 6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,12 @@
   "enabledManagers": [
     "npm"
   ],
+  "force": {
+    "constraints": {
+      "node": "< 15.0.0"
+    }
+  },
+  "pruneStaleBranches": false,
   "rangeStrategy": "bump",
   "commitMessagePrefix": "patch:",
   "commitBody": "Change-type: patch",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

This change forces Renovate to use Node 14 and therefore npm 6, which should resolve our `package-lock.json` `lockfileVersion` update problem.

Renovate doc: https://docs.renovatebot.com/configuration-options/#constraints